### PR TITLE
uploaded file link was not pass to <audio> src

### DIFF
--- a/src/froala-audio.js
+++ b/src/froala-audio.js
@@ -547,6 +547,7 @@
           }
 
           try {
+            response = parseResponse(response);//should parse the response before you can use the link
             if (response) insertHtmlAudio(response.link, responseText);
           } catch (ex) {
             // Bad response.


### PR DESCRIPTION
response should be parsed before you can use the "link" property